### PR TITLE
Corrige bug na definição do valor da transação

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,11 @@
             "name": "William G. Comnisky",
             "email": "w.comnisky@gmail.com",
             "role": "developer"
+        },
+        {
+            "name": "Thiago Rodrigues",
+            "email": "xthiago@gmail.com",
+            "role": "developer"
         }
     ],
     "support": {

--- a/src/MrPrompt/Cielo/Transacao.php
+++ b/src/MrPrompt/Cielo/Transacao.php
@@ -368,7 +368,7 @@ class Transacao
      * Configura o valor da venda
      *
      * O valor da venda é um inteiro sem separador, onde os dois últimos
-     * digitos referem-se aos centavos. Ex.: 1200 = R$ 12,00
+     * digitos referem-se aos centavos. Ex.: 1237 = R$ 12,37
      *
      * @access public
      * @param  integer $valor
@@ -377,12 +377,14 @@ class Transacao
     public function setValor($valor)
     {
         if (preg_match('/([[:alpha:]]|[[:punct:]]|[[:space:]])/', $valor)) {
-            throw new InvalidArgumentException('Valor inválido.');
+            throw new InvalidArgumentException('Valor inválido. Deve conter apenas números inteiros.');
         }
 
-        $valor = number_format ( (float) $valor, 2, '' , '' );
+        if (!preg_match('/^[[:digit:]]{1,12}$/', $valor)) {
+            throw new InvalidArgumentException('Valor inválido. Deve conter de 1 à 12 digitos.');
+        }
 
-        $this->valorPedido = substr($valor, 0, 12);
+        $this->valorPedido = $valor;
 
         return $this;
     }


### PR DESCRIPTION
Transacao::setValor() exige que o argumento $valor seja do tipo integer de modo que os valores monetários sejam expressos em centavos (exemplo: R$ 14,37 = 1437), conforme especificação da
Cielo. Inclusive há validação para impedir caracteres alfanuméricos, digitos e pontuação.

A implementação anterior acrescentava dois digitos ao final do número recebido, transformando 1437 (R$ 14,37) em 143700 (R$ 1437,00), não deixando que especifiquemos os centavos. Não faz sentido aplicar number_format no valor recebido se já é exigido que os mesmos sejam recebidos como integer (conforme mencionado no 1º parágrafo). Removi essa linha.

Aproveitando a oportunidade, substitui o truncamento do valor para o tamanho máximo especificado pela Cielo ($this->valorPedido = substr($valor, 0, 12);) por uma validação de tamanho usando regex. Julgo ser melhor lançar uma exceção caso o tamanho do $valor exceda o limite do que tratar isso implicitamente, pois a implementação anterior poderia gerar uma transação com valor inferior ao solicitado.

Por fim, tentei deixar as mensagens de exceção lançadas por esse método mais claras ao desenvolvedor (do que simplesmente "valor inválido").
