### PR TITLE
Remove elemento bin quando número do cartão é vazio ou nulo

### DIFF
--- a/src/MrPrompt/Cielo/Requisicao/SolicitacaoTransacao.php
+++ b/src/MrPrompt/Cielo/Requisicao/SolicitacaoTransacao.php
@@ -41,7 +41,7 @@ class SolicitacaoTransacao extends Requisicao
 
     /**
      * Cartão a ser utilizado
-     * 
+     *
      * Para modalidade Cielo, basta que o atributo Cartao::bandeira seja informado.
      *
      * @var Cartao
@@ -117,7 +117,13 @@ class SolicitacaoTransacao extends Requisicao
         $this->getEnvio()->addChild('capturar', $this->transacao->getCapturar());
         $this->getEnvio()->addChild('campo-livre', '');
 
-        if (Autorizacao::MODALIDADE_BUY_PAGE_LOJA === $this->getModalidadeIntegracao()) {
+        if (Autorizacao::MODALIDADE_BUY_PAGE_LOJA !== $this->getModalidadeIntegracao())
+            return;
+
+        $numeroCartao = $this->cartao->getCartao();
+
+        if (! empty($numeroCartao)) {
+
             $this->getEnvio()->addChild('bin', substr($this->cartao->getCartao(), 0, 6));
         }
     }


### PR DESCRIPTION
O método `Cliente::iniciaTransacao` enviava um XML inválido para
o WebService da Cielo quando era fornecido um token ao invés dos
dados planos cartão.

Requisição:

```
<?xml version="1.0" encoding="UTF-8"?>
<requisicao-transacao id="1" versao="1.1.0">
   <dados-ec>
      <numero>1001734898</numero>
      <chave>e84827130b9837473681c2787007da5914d6359947015a5cdb2b8843db0fa832</chave>
   </dados-ec>
   <dados-portador>
      <token>xZDhZlyWP4IXCwFSC/bFlVrGRXtS0wuyl6WuujQ6bOc=</token>
   </dados-portador>
   <dados-pedido>
      <numero>12312</numero>
      <valor>10000</valor>
      <moeda>986</moeda>
      <data-hora>2014-09-11T17:30:11</data-hora>
      <descricao>Descrição</descricao>
      <idioma>PT</idioma>
   </dados-pedido>
   <forma-pagamento>
      <bandeira>visa</bandeira>
      <produto>1</produto>
      <parcelas>1</parcelas>
   </forma-pagamento>
   <url-retorno>http://example.com.br</url-retorno>
   <autorizar>3</autorizar>
   <capturar>false</capturar>
   <campo-livre />
   <bin />
</requisicao-transacao>
```

Resposta do webservice:

```
<?xml version="1.0" encoding="ISO-8859-1"?>
<erro xmlns="http://ecommerce.cbmp.com.br"><codigo>001</codigo><mensagem><![CDATA[
O XML informado não é valido:
- string value '' does not match pattern for type of bin element in RequisicaoNovaTransacao in namespace http://ecommerce.cbmp.com.br: '<xml-fragment/>'
]]></mensagem></erro>
```

Isso ocorria  porque era incluído o elemento `<bin />` (vazio) no
xml da requisita-transacao (`SolicitacaoTransacao::configure`).

Este commit resolve o problema incluíndo uma verificação. O `<bin>`
somente é incluído se `Cartao::cartao` for preenchido.
