### PR TITLE
Corrige o unknow SSL error com a libcurl versão 7.35, referencia: https:...

### DIFF
--- a/src/MrPrompt/Cielo/Cliente.php
+++ b/src/MrPrompt/Cielo/Cliente.php
@@ -411,11 +411,11 @@ class Cliente
     protected function enviaRequisicao(Requisicao $requisicao)
     {
         $request = $this->httpClient->post($this->getEndpoint())
-                                    ->addPostFields(
-                                        array(
-                                            'mensagem' => $requisicao->getEnvio()->asXML()
-                                        )
-                                    );
+                                    ->addPostFields(array(
+                                        'mensagem' => $requisicao->getEnvio()->asXML()
+                                    ))
+                                    ->getCurlOptions()->set(CURLOPT_SSLVERSION, 3);
+
 
         $requisicao->setResposta($request->send()->xml());
 


### PR DESCRIPTION
Correção do Erro unknown host da libcurl 7.35, vi que já há um pull request sobre isso, entretando no dev-master do composer o mesmo não funcionou e o problema persistiu.
