### PR TITLE
Bugfix : Ajustando a forma como foi definida a versão do SSL no cURL.

### DIFF
--- a/src/MrPrompt/Cielo/Cliente.php
+++ b/src/MrPrompt/Cielo/Cliente.php
@@ -413,9 +413,7 @@ class Cliente
         $request = $this->httpClient->post($this->getEndpoint())
                                     ->addPostFields(array(
                                         'mensagem' => $requisicao->getEnvio()->asXML()
-                                    ))
-                                    ->getCurlOptions()->set(CURLOPT_SSLVERSION, 3);
-
+                                    ));
 
         $request->getCurlOptions()->set(CURLOPT_SSLVERSION, 3);
 


### PR DESCRIPTION
No commit aeb5309cc919dd81132881be31eeca761a599920 foi adicionada a chamada ao
método que retorna a coleção de opções do cURL para o HTTP Client, seguida da
definição da versão do SSL. O problema é que o método foi adicionado na cadeia
(chain) que retornava o objeto do request, que passou a retornar a coleção de
opções e gerava exceções como:

Call to undefined method Guzzle\Common\Collection::send()

Para resolver, a chamada a coleção de opções foi removida da cadeia e foi
mantida apenas a linha 420 (que era uma duplicata daquela chamada). Assim o
último método da cadeia fica sendo o addPostFields que ainda retorna a
requisição.