### PR TITLE
Adicionado funcionalidade de cancelamento parcial

### DIFF
--- a/src/MrPrompt/Cielo/Requisicao/CancelamentoTransacao.php
+++ b/src/MrPrompt/Cielo/Requisicao/CancelamentoTransacao.php
@@ -48,4 +48,14 @@ class CancelamentoTransacao extends Requisicao
             'requisicao-cancelamento'
         );
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configuraEnvio()
+    {
+        if (!empty($this->transacao->getValor())) {
+            $this->getEnvio()->addChild('valor', $this->transacao->getValor());
+        }
+    }
 }

--- a/src/MrPrompt/Cielo/Requisicao/CancelamentoTransacao.php
+++ b/src/MrPrompt/Cielo/Requisicao/CancelamentoTransacao.php
@@ -54,8 +54,9 @@ class CancelamentoTransacao extends Requisicao
      */
     protected function configuraEnvio()
     {
-        if (!empty($this->transacao->getValor())) {
-            $this->getEnvio()->addChild('valor', $this->transacao->getValor());
+        $valor = $this->transacao->getValor();
+        if (!empty($valor)) {
+            $this->getEnvio()->addChild('valor', $valor);
         }
     }
 }


### PR DESCRIPTION
Sobrescrito o método configuraEnvio para identificar se foi informado o valor da transação, e neste caso o cancelamento deve ser parcial no valor da transação informada