### PR TITLE
Corrige tipo de retorno para Transacao

### DIFF
--- a/src/Cliente.php
+++ b/src/Cliente.php
@@ -290,9 +290,10 @@ class Cliente
      * Realiza o envio da requisição à Cielo
      *
      * @param Requisicao $requisicao
-     * @return object
+     * @return Transacao
+     * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    protected function enviaRequisicao(Requisicao $requisicao): object
+    protected function enviaRequisicao(Requisicao $requisicao): Transacao
     {
         $response = $this
             ->httpClient


### PR DESCRIPTION
O tipo estava anteriormente como object, que estava causando uma exception.
Não conseguia obter o valor da resposta em função disso.